### PR TITLE
Update CHMI service URL in Config.php

### DIFF
--- a/aplikace/app/Services/Config.php
+++ b/aplikace/app/Services/Config.php
@@ -18,7 +18,7 @@ class Config
     /**
      * URL sluzby CHMI
      */
-    public $url = 'https://www.chmi.cz/files/portal/docs/meteo/om/bulletiny/XOCZ50_OKPR.xml';
+    public $url = 'https://vystrahy-cr.chmi.cz/data/XOCZ50_OKPR.xml';
 
     /**
      * Jak dlouho plati stazeny soubor, sekundy


### PR DESCRIPTION
Vypadá to, že 18. 12. 2025 při migraci webu CHMI změnilo cestu k souboru s výstrahami. Tohle je nová URL